### PR TITLE
Add no-return-assign to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
     "no-multi-spaces": "off",
     "no-multiple-empty-lines": "off",
     "no-reserved-keys": "off",
+    "no-return-assign": "off",
     "no-space-before-semi": "off",
     "no-spaced-func": "off",
     "no-trailing-spaces": "off",


### PR DESCRIPTION
The Airbnb eslint config  (https://github.com/airbnb/javascript/blob/75d48c7570b2c5336c75c454ce91991a34d0554e/packages/eslint-config-airbnb-base/rules/best-practices.js#L208) establishes that not surrounding a variable assignment in a one-line arrow statement is a linter error. Prettier removes the parentheses, causing the linter to fail because of the eslint config. I propose disabling the no-return-assign rule