### PR TITLE
Turn off indent-legacy

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
     "generator-star": "off",
     "generator-star-spacing": "off",
     indent: "off",
+    "indent-legacy": "off",
     "jsx-quotes": "off",
     "key-spacing": "off",
     "keyword-spacing": "off",


### PR DESCRIPTION
New rule indent-legacy introduced in v4 functions similarly to indent. Conflicts with prettier.