### PR TITLE
Prettier cares about lines-around-comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,30 @@ Example configuration:
 }
 ```
 
+### [lines-around-comment]
+
+**This rule can be used with certain options.**
+
+It is possible to use this rule with some options.
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "lines-around-comment": ["error", { 
+        "allowBlockStart": true,
+        "allowBlockEnd": true,
+        "allowObjectStart": true,
+        "allowObjectEnd": true,
+        "allowArrayStart": true,
+        "allowArrayEnd": true,
+    }]
+  }
+}
+```
+
+
 ## Contributing
 
 eslint-config-prettier has been tested with:
@@ -403,5 +427,6 @@ several other npm scripts:
 [no-tabs]: https://eslint.org/docs/rules/no-tabs
 [Prettier]: https://github.com/prettier/prettier
 [quotes]: https://eslint.org/docs/rules/quotes
+[lines-around-comment]: https://eslint.org/docs/rules/lines-around-comment
 [travis-badge]: https://travis-ci.org/prettier/eslint-config-prettier.svg?branch=master
 [travis]: https://travis-ci.org/prettier/eslint-config-prettier

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Example configuration:
     "lines-around-comment": [
       "error",
       {
+        "beforeBlockComment": true,
+        "afterBlockComment": true,
+        "beforeLineComment": true,
+        "afterLineComment": true,
         "allowBlockStart": true,
         "allowBlockEnd": true,
         "allowObjectStart": true,

--- a/README.md
+++ b/README.md
@@ -174,14 +174,17 @@ Example configuration:
 ```json
 {
   "rules": {
-    "lines-around-comment": ["error", { 
+    "lines-around-comment": [
+      "error",
+      {
         "allowBlockStart": true,
         "allowBlockEnd": true,
         "allowObjectStart": true,
         "allowObjectEnd": true,
         "allowArrayStart": true,
         "allowArrayEnd": true,
-    }]
+      }
+    ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Example configuration:
         "allowObjectStart": true,
         "allowObjectEnd": true,
         "allowArrayStart": true,
-        "allowArrayEnd": true,
+        "allowArrayEnd": true
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -167,7 +167,36 @@ Example configuration:
 
 **This rule can be used with certain options.**
 
-It is possible to use this rule with some options.
+This rule requires empty lines before and/or after comments. Prettier preserves
+blank lines, with two exceptions:
+
+- Several blank lines in a row are collapsed into a single blank line. This is
+  fine.
+- Blank lines at the beginning and end of blocks, objects and arrays are always
+  removed. This may lead to conflicts.
+
+By default, ESLint requires a blank line above the comment is this case:
+
+```js
+if (result) {
+
+  /* comment */
+  return result;
+}
+```
+
+However, Prettier removes the blank line:
+
+```js
+if (result) {
+  /* comment */
+  return result;
+}
+```
+
+If you like this rule, it can be used just fine with Prettier as long as add
+extra configuration to allow comments at the start and end of blocks, objects
+and arrays.
 
 Example configuration:
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,29 @@ Example configuration:
 }
 ```
 
+### [lines-around-comment]
+
+**This rule can be used with certain options.**
+
+It is possible to use this rule with some options.
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "lines-around-comment": ["error", { 
+        "allowBlockStart": true,
+        "allowBlockEnd": true,
+        "allowObjectStart": true,
+        "allowObjectEnd": true,
+        "allowArrayStart": true,
+        "allowArrayEnd": true,
+    }]
+  }
+}
+```
+
 ### [max-len]
 
 **This rule requires special attention when writing code.**
@@ -319,29 +342,6 @@ Example configuration:
 }
 ```
 
-### [lines-around-comment]
-
-**This rule can be used with certain options.**
-
-It is possible to use this rule with some options.
-
-Example configuration:
-
-```json
-{
-  "rules": {
-    "lines-around-comment": ["error", { 
-        "allowBlockStart": true,
-        "allowBlockEnd": true,
-        "allowObjectStart": true,
-        "allowObjectEnd": true,
-        "allowArrayStart": true,
-        "allowArrayEnd": true,
-    }]
-  }
-}
-```
-
 
 ## Contributing
 
@@ -415,18 +415,18 @@ several other npm scripts:
 
 [MIT](LICENSE).
 
+[Prettier]: https://github.com/prettier/prettier
 [curly]: https://eslint.org/docs/rules/curly
 [eslint-config-airbnb]: https://www.npmjs.com/package/eslint-config-airbnb
 [eslint-plugin-flowtype]: https://github.com/gajus/eslint-plugin-flowtype
 [eslint-plugin-prettier]: https://github.com/prettier/eslint-plugin-prettier
 [eslint-plugin-react]: https://github.com/yannickcr/eslint-plugin-react
 [eslint-plugin-standard]: https://github.com/xjamundx/eslint-plugin-standard
+[lines-around-comment]: https://eslint.org/docs/rules/lines-around-comment
 [max-len]: https://eslint.org/docs/rules/max-len
 [no-confusing-arrow]: https://eslint.org/docs/rules/no-confusing-arrow
 [no-mixed-operators]: https://eslint.org/docs/rules/no-mixed-operators
 [no-tabs]: https://eslint.org/docs/rules/no-tabs
-[Prettier]: https://github.com/prettier/prettier
 [quotes]: https://eslint.org/docs/rules/quotes
-[lines-around-comment]: https://eslint.org/docs/rules/lines-around-comment
 [travis-badge]: https://travis-ci.org/prettier/eslint-config-prettier.svg?branch=master
 [travis]: https://travis-ci.org/prettier/eslint-config-prettier

--- a/bin/validators.js
+++ b/bin/validators.js
@@ -10,6 +10,23 @@ module.exports = {
     return firstOption !== "multi-line" && firstOption !== "multi-or-nest";
   },
 
+  "lines-around-comment"(options) {
+    if (options.length < 1) {
+      return false;
+    }
+
+    const firstOption = options[0];
+    return Boolean(
+      firstOption &&
+        firstOption.allowBlockStart &&
+        firstOption.allowBlockEnd &&
+        firstOption.allowObjectStart &&
+        firstOption.allowObjectEnd &&
+        firstOption.allowArrayStart &&
+        firstOption.allowArrayEnd
+    );
+  },
+
   "no-confusing-arrow"(options) {
     if (options.length < 1) {
       return true;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     // information. (These are marked with `0` instead of `"off"` so that a
     // script can distinguish them.)
     curly: 0,
+    "lines-around-comment": 0,
     "max-len": 0,
     "no-confusing-arrow": 0,
     "no-mixed-operators": 0,
@@ -34,7 +35,6 @@ module.exports = {
     "jsx-quotes": "off",
     "key-spacing": "off",
     "keyword-spacing": "off",
-    "lines-around-comment": "off",
     "multiline-ternary": "off",
     "newline-per-chained-call": "off",
     "new-parens": "off",

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
     "jsx-quotes": "off",
     "key-spacing": "off",
     "keyword-spacing": "off",
+    "lines-around-comment": "off",
     "multiline-ternary": "off",
     "newline-per-chained-call": "off",
     "new-parens": "off",

--- a/test/cli.js
+++ b/test/cli.js
@@ -136,6 +136,7 @@ test(
     "quotes",
     "arrow-parens",
     "no-tabs",
+    "lines-around-comment",
     "no-mixed-operators",
     ["curly", "multi-or-nest", "consistent"],
     ["no-confusing-arrow", { allowParens: true }],
@@ -154,6 +155,7 @@ test(
     https://github.com/prettier/eslint-config-prettier#special-rules
 
     - curly
+    - lines-around-comment
     - no-confusing-arrow
     - quotes
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -22,6 +22,39 @@ test("curly", t => {
   );
 });
 
+test("lines-around-comment", t => {
+  t.false(validators["lines-around-comment"]([]), "no options disallowed");
+  t.true(
+    validators["lines-around-comment"]([
+      {
+        allowBlockStart: true,
+        allowBlockEnd: true,
+        allowObjectStart: true,
+        allowObjectEnd: true,
+        allowArrayStart: true,
+        allowArrayEnd: true
+      }
+    ]),
+    "allowing block/object/array start/end allowed"
+  );
+  t.false(
+    validators["lines-around-comment"]([
+      {
+        allowBlockEnd: true,
+        allowObjectStart: true,
+        allowObjectEnd: true,
+        allowArrayStart: true,
+        allowArrayEnd: true
+      }
+    ]),
+    "missing one of the options disallowed"
+  );
+  t.false(
+    validators["lines-around-comment"]([null]),
+    "does not crash on bad input"
+  );
+});
+
 test("no-confusing-arrow", t => {
   t.true(validators["no-confusing-arrow"]([]), "no options allowed");
   t.true(


### PR DESCRIPTION
Prettier will remove lines above comments. This fails with the default settings used in a Preact CLI app where `'lines-around-comment': 2,` is included in the eslint configuration.