### PR TITLE
Disable no-unexpected-multiline, document as special case

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,41 +354,62 @@ Example configuration:
 
 ### [no-unexpected-multiline]
 
+**This rule requires special attention when writing code.**
+
 This rule disallows confusing multiline expressions where a newline looks like
 it is ending a statement, but is not.
 
 For example, the rule could warn about this:
 
 ```js
-var hello = 'world' // semicolon missing
+var hello = "world"
 [1, 2, 3].forEach(addNumber)
 ```
 
-Note that, prettier would format this in a way which would be more indicative
-of the problem(the missing `;`):
+Prettier usually formats this in a way that makes it obvious that a semicolon
+was missing:
 
 ```js
-var hello = 'world'[(1, 2, 3)].forEach(addNumber);
+var hello = "world"[(1, 2, 3)].forEach(addNumber);
 ```
 
-However, there are cases where prettier and the `no-unexpected-multiline` rule
-would confict without any possible resolution. In the following example,
-prettier breaks up the expression over multiple lines but the eslint rule
-reports an error:
+However, there are cases where Prettier breaks things into several lines such
+that the `no-unexpected-multiline` conflicts.
 
 ```js
-const value = getInstance()
-    [modeName]()
-    .toJSON()
+const value = text.trim().split("\n")[position].toLowerCase();
 ```
 
-The eslint `recommended` config as well as the [eslint-config-airbnb] config
-have this rule turned on by default. So makes sense for eslint-config-prettier
-to turn this rule off.
+Prettier breaks it up into several lines, though, causing a conflict:
 
-If you like this rule, it can be used with prettier but you would have to
-disable it using comment directives specifically for the unresolvable
-instances.
+```js
+const value = text
+  .trim()
+  .split("\n")
+  [position].toLowerCase();
+```
+
+If you like this rule, it can usually be used with Prettier without problems,
+but occasionally you might need to either temporarily disable the rule or
+refactor your code.
+
+```js
+const value = text
+  .trim()
+  .split("\n")
+  // eslint-disable-next-line no-unexpected-multiline
+  [position].toLowerCase();
+
+// Or:
+
+const lines = text.trim().split("\n");
+const value = lines[position].toLowerCase();
+```
+
+**Note:** If you _do_ enable this rule, you have to run ESLint and Prettier as
+two separate steps (and ESLint first) in order to get any value out of it.
+Otherwise Prettier might reformat your code in such a way that ESLint never gets
+a chance to report anything (as seen in the first example).
 
 Example configuration:
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,54 @@ Example configuration:
 }
 ```
 
+### [no-unexpected-multiline]
+
+This rule disallows confusing multiline expressions where a newline looks like
+it is ending a statement, but is not.
+
+For example, the rule could warn about this:
+
+```js
+var hello = 'world' // semicolon missing
+[1, 2, 3].forEach(addNumber)
+```
+
+Note that, prettier would format this in a way which would be more indicative
+of the problem(the missing `;`):
+
+```js
+var hello = 'world'[(1, 2, 3)].forEach(addNumber);
+```
+
+However, there are cases where prettier and the `no-unexpected-multiline` rule
+would confict without any possible resolution. In the following example,
+prettier breaks up the expression over multiple lines but the eslint rule
+reports an error:
+
+```js
+const value = getInstance()
+    [modeName]()
+    .toJSON()
+```
+
+The eslint `recommended` config as well as the [eslint-config-airbnb] config
+have this rule turned on by default. So makes sense for eslint-config-prettier
+to turn this rule off.
+
+If you like this rule, it can be used with prettier but you would have to
+disable it using comment directives specifically for the unresolvable
+instances.
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "no-unexpected-multiline": "error"
+  }
+}
+```
+
 ## Contributing
 
 eslint-config-prettier has been tested with:
@@ -403,5 +451,6 @@ several other npm scripts:
 [no-tabs]: https://eslint.org/docs/rules/no-tabs
 [Prettier]: https://github.com/prettier/prettier
 [quotes]: https://eslint.org/docs/rules/quotes
+[no-unexpected-multiline]: https://eslint.org/docs/rules/no-unexpected-multiline
 [travis-badge]: https://travis-ci.org/prettier/eslint-config-prettier.svg?branch=master
 [travis]: https://travis-ci.org/prettier/eslint-config-prettier

--- a/README.md
+++ b/README.md
@@ -352,24 +352,6 @@ Example configuration:
 }
 ```
 
-### [quotes]
-
-**This rule requires certain options.**
-
-If you’d like to enforce the use of backticks rather than single or double
-quotes for strings, you can enable this rule. Otherwise, there’s no need to.
-Just remember to enable the `"backtick"` option!
-
-Example configuration:
-
-```json
-{
-  "rules": {
-    "quotes": ["error", "backtick"]
-  }
-}
-```
-
 ### [no-unexpected-multiline]
 
 This rule disallows confusing multiline expressions where a newline looks like
@@ -414,6 +396,24 @@ Example configuration:
 {
   "rules": {
     "no-unexpected-multiline": "error"
+  }
+}
+```
+
+### [quotes]
+
+**This rule requires certain options.**
+
+If you’d like to enforce the use of backticks rather than single or double
+quotes for strings, you can enable this rule. Otherwise, there’s no need to.
+Just remember to enable the `"backtick"` option!
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "quotes": ["error", "backtick"]
   }
 }
 ```
@@ -502,7 +502,7 @@ several other npm scripts:
 [no-confusing-arrow]: https://eslint.org/docs/rules/no-confusing-arrow
 [no-mixed-operators]: https://eslint.org/docs/rules/no-mixed-operators
 [no-tabs]: https://eslint.org/docs/rules/no-tabs
-[quotes]: https://eslint.org/docs/rules/quotes
 [no-unexpected-multiline]: https://eslint.org/docs/rules/no-unexpected-multiline
+[quotes]: https://eslint.org/docs/rules/quotes
 [travis-badge]: https://travis-ci.org/prettier/eslint-config-prettier.svg?branch=master
 [travis]: https://travis-ci.org/prettier/eslint-config-prettier

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = {
     "no-confusing-arrow": 0,
     "no-mixed-operators": 0,
     "no-tabs": 0,
-    quotes: 0,
     "no-unexpected-multiline": 0,
+    quotes: 0,
     // The rest are rules that you never need to enable when using Prettier.
     "array-bracket-newline": "off",
     "array-bracket-spacing": "off",

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     "no-mixed-operators": 0,
     "no-tabs": 0,
     quotes: 0,
+    "no-unexpected-multiline": 0,
     // The rest are rules that you never need to enable when using Prettier.
     "array-bracket-newline": "off",
     "array-bracket-spacing": "off",

--- a/test/cli.js
+++ b/test/cli.js
@@ -137,6 +137,7 @@ test(
     "arrow-parens",
     "no-tabs",
     "lines-around-comment",
+    "no-unexpected-multiline",
     "no-mixed-operators",
     ["curly", "multi-or-nest", "consistent"],
     ["no-confusing-arrow", { allowParens: true }],
@@ -165,6 +166,7 @@ test(
     - max-len
     - no-mixed-operators
     - no-tabs
+    - no-unexpected-multiline
   `,
   2
 );


### PR DESCRIPTION
This disables the eslint rule `no-unexpected-multiline` which is part of the recommended eslint config. Additionally, as suggested by @lydell, it is marked as a special case.

Closes #32.