### PR TITLE
Fix tests, script failing on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:lint-verify-fail": "eslint test-lint/ --config .eslintrc.base.js --format json",
     "test:lint-rules": "eslint index.js --config test-config/.eslintrc.js --format json",
     "test:ava": "ava",
-    "test:cli-sanity": "eslint --print-config .eslintrc.js | ./bin/cli.js",
+    "test:cli-sanity": "eslint --print-config .eslintrc.js | node ./bin/cli.js",
     "test": "npm run test:lint && npm run test:ava && npm run test:cli-sanity"
   },
   "dependencies": {
@@ -34,6 +34,7 @@
   "devDependencies": {
     "ava": "^0.23.0",
     "babel-eslint": "^7.2.3",
+    "cross-spawn": "^5.1.0",
     "dedent": "^0.7.0",
     "eslint": "^4.10.0",
     "eslint-config-google": "^0.9.1",

--- a/test/helpers/get-env.js
+++ b/test/helpers/get-env.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function getEnv() {
+  // this is required to address an issue in cross-spawn on windows
+  // https://github.com/IndigoUnited/node-cross-spawn/issues/80
+  return Object.keys(process.env)
+    .filter(key => process.env[key] !== undefined)
+    .reduce((envCopy, key) => {
+      envCopy[key] = process.env[key];
+      return envCopy;
+    }, {});
+};

--- a/test/lint-verify-fail.js
+++ b/test/lint-verify-fail.js
@@ -1,19 +1,20 @@
 "use strict";
 
 const test = require("ava");
-const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const spawn = require("cross-spawn");
+const getEnv = require("./helpers/get-env");
 
 const ruleFiles = fs
   .readdirSync(".")
   .filter(name => !name.startsWith(".") && name.endsWith(".js"));
 
 test("test-lint/ causes errors without eslint-config-prettier", t => {
-  const result = childProcess.spawnSync(
+  const result = spawn.sync(
     "npm",
     ["run", "test:lint-verify-fail", "--silent"],
-    { encoding: "utf8" }
+    { encoding: "utf8", env: getEnv() }
   );
   const output = JSON.parse(result.stdout);
 

--- a/test/rules.js
+++ b/test/rules.js
@@ -1,13 +1,14 @@
 "use strict";
 
 const test = require("ava");
-const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const rimraf = require("rimraf");
+const spawn = require("cross-spawn");
 const pkg = require("../package.json");
 const eslintConfig = require("../.eslintrc");
 const eslintConfigBase = require("../.eslintrc.base");
+const getEnv = require("./helpers/get-env");
 
 const TEST_CONFIG_DIR = "test-config";
 
@@ -117,11 +118,10 @@ test('All rules are set to "off" or 0', t => {
 });
 
 test("There are no unknown rules", t => {
-  const result = childProcess.spawnSync(
-    "npm",
-    ["run", "test:lint-rules", "--silent"],
-    { encoding: "utf8" }
-  );
+  const result = spawn.sync("npm", ["run", "test:lint-rules", "--silent"], {
+    encoding: "utf8",
+    env: getEnv()
+  });
   const output = JSON.parse(result.stdout);
 
   output[0].messages.forEach(message => {


### PR DESCRIPTION
This fixes the tests failing on windows. I also tweaked the script for `test:cli-sanity` because it was causing this issue:

```
λ yarn test
yarn run v1.2.1
$ npm run test:lint && npm run test:ava && npm run test:cli-sanity

> eslint-config-prettier@2.7.0 test:lint E:\Projects\repos\eslint-config-prettier
> eslint .


> eslint-config-prettier@2.7.0 test:ava E:\Projects\repos\eslint-config-prettier
> ava


  26 passed

> eslint-config-prettier@2.7.0 test:cli-sanity E:\Projects\repos\eslint-config-prettier
> eslint --print-config .eslintrc.js | ./bin/cli.js

'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 255
npm ERR! eslint-config-prettier@2.7.0 test:cli-sanity: `eslint --print-config .eslintrc.js | ./bin/cli.js`
npm ERR! Exit status 255
npm ERR!
npm ERR! Failed at the eslint-config-prettier@2.7.0 test:cli-sanity script.
```

Closes #35.