### PR TITLE
Remove "standard" from "plugins" in Example Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Exit codes:
   "plugins": [
     "flowtype",
     "react",
-    "prettier",
-    "standard"
+    "prettier"
   ],
   "parserOptions": {
     "sourceType": "module",


### PR DESCRIPTION
`eslint-config-standard` (which is used in the example) [already specifies `eslint-plugin-standard` as a plugin](https://github.com/standard/eslint-config-standard/blob/master/eslintrc.json#L20), so this line is redundant.