### PR TITLE
chore(vue): Use dedicated vue/no-layout-rules config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,12 +1977,12 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "5.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.0.0-beta.3.tgz",
-      "integrity": "sha512-EOQo3ax4CIM6Itcl522p4cGlSBgR/KZBJo2Xc29PWknbYH/DRZorGutF8NATUpbZ4HYOG+Gcyd1nL08iyYF3Tg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.1.0.tgz",
+      "integrity": "sha512-C7avvbGLb9J1PyGiFolPcGR4ljUc+dKm5ZJdrUKXwXFxHHx4SqOmRI29AsFyW7PbCGcnOvIlaq7NJS6HDIak+g==",
       "dev": true,
       "requires": {
-        "vue-eslint-parser": "^3.2.1"
+        "vue-eslint-parser": "^4.0.2"
       }
     },
     "eslint-scope": {
@@ -6535,19 +6535,28 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-3.2.2.tgz",
-      "integrity": "sha512-dprI6ggKCTwV22r+i8dtUGquiOCn063xyDmb7BV/BjG5Oc/m5EoMNrWevpvTcrlGuFZmYVPs5fgsu8UIxmMKzg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-4.0.3.tgz",
+      "integrity": "sha512-AUeQsYdO6+7QXCems+WvGlrXd37PHv/zcRQSQdY1xdOMwdFAPEnMBsv7zPvk0TPGulXkK/5p/ITgrjiYB7k3ag==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "espree": "^4.1.0",
         "esquery": "^1.0.1",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "eslint-scope": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-standard": "4.0.0",
     "eslint-plugin-unicorn": "6.0.1",
-    "eslint-plugin-vue": "5.0.0-beta.3",
+    "eslint-plugin-vue": "^5.0.0",
     "jest": "23.6.0",
     "prettier": "1.15.2",
     "replace": "1.0.0",

--- a/vue.js
+++ b/vue.js
@@ -1,20 +1,8 @@
 "use strict";
 
 module.exports = {
+  extends: "plugin:vue/no-layout-rules",
   rules: {
-    "vue/html-self-closing": 0,
-
-    "vue/html-closing-bracket-newline": "off",
-    "vue/html-closing-bracket-spacing": "off",
-    "vue/html-end-tags": "off",
-    "vue/html-indent": "off",
-    "vue/html-quotes": "off",
-    "vue/max-attributes-per-line": "off",
-    "vue/multiline-html-element-content-newline": "off",
-    "vue/mustache-interpolation-spacing": "off",
-    "vue/no-multi-spaces": "off",
-    "vue/no-spaces-around-equal-signs-in-attribute": "off",
-    "vue/script-indent": "off",
-    "vue/singleline-html-element-content-newline": "off"
+    "vue/html-self-closing": 0
   }
 };


### PR DESCRIPTION
This PR updates `eslint-plugin-vue`, as well as updates `vue` config, by using brand new `vue/no-layout-rules` config, that is automatically generated based on the `type` property in rules' metadata. This way we won't get out-of-sync :)