### PR TITLE
Add support for eslint-plugin-babel

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -42,7 +42,10 @@ module.exports = {
     "react/jsx-filename-extension": "off",
     "react/jsx-no-bind": "off",
     // Force a conflict with Prettier in test-lint/standard.js.
-    "standard/computed-property-even-spacing": ["error", "even"]
+    "standard/computed-property-even-spacing": ["error", "even"],
+    // Force a conflict with Prettier in test-lint/babel.js.
+    "object-curly-spacing": "off",
+    "babel/object-curly-spacing": ["error", "never"]
   },
   overrides: [
     {

--- a/README.md
+++ b/README.md
@@ -711,13 +711,13 @@ eslint-config-prettier has been tested with:
   - eslint-config-prettier 2.10.0 and older were tested with ESLint 4.x
   - eslint-config-prettier 2.1.1 and older were tested with ESLint 3.x
 - prettier 1.15.3
+- eslint-plugin-babel 5.3.0
 - eslint-plugin-flowtype 3.2.1
 - eslint-plugin-react 7.12.3
 - eslint-plugin-standard 4.0.0
 - eslint-plugin-typescript 1.0.0-rc.1
 - eslint-plugin-unicorn 7.0.0
 - eslint-plugin-vue 5.1.0
-- eslint-plugin-babel 5.3.0
 
 Have new rules been added since those versions? Have we missed any rules? Is
 there a plugin you would like to see exclusions for? Open an issue or a pull
@@ -787,6 +787,7 @@ several other npm scripts:
 [Prettier]: https://github.com/prettier/prettier
 [babel/quotes]: https://github.com/babel/eslint-plugin-babel#rules
 [curly]: https://eslint.org/docs/rules/curly
+[eslint-plugin-babel]: https://github.com/babel/eslint-plugin-babel
 [eslint-plugin-flowtype]: https://github.com/gajus/eslint-plugin-flowtype
 [eslint-plugin-prettier]: https://github.com/prettier/eslint-plugin-prettier
 [eslint-plugin-react]: https://github.com/yannickcr/eslint-plugin-react
@@ -794,7 +795,6 @@ several other npm scripts:
 [eslint-plugin-typescript]: https://github.com/bradzacher/eslint-plugin-typescript
 [eslint-plugin-unicorn]: https://github.com/sindresorhus/eslint-plugin-unicorn
 [eslint-plugin-vue]: https://github.com/vuejs/eslint-plugin-vue
-[eslint-plugin-babel]: https://github.com/babel/eslint-plugin-babel
 [lines-around-comment]: https://eslint.org/docs/rules/lines-around-comment
 [max-len]: https://eslint.org/docs/rules/max-len
 [multiple configuration files]: https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ configs.
 
 A few ESLint plugins are supported as well:
 
+- [eslint-plugin-babel]
 - [eslint-plugin-flowtype]
 - [eslint-plugin-react]
 - [eslint-plugin-standard]
@@ -73,6 +74,7 @@ Add extra exclusions for the plugins you use like so:
 {
   "extends": [
     "prettier",
+    "prettier/babel",
     "prettier/flowtype",
     "prettier/react",
     "prettier/standard",
@@ -127,6 +129,7 @@ Exit codes:
     "plugin:unicorn/recommended",
     "plugin:vue/recommended",
     "prettier",
+    "prettier/babel",
     "prettier/flowtype",
     "prettier/react",
     "prettier/standard",
@@ -135,6 +138,7 @@ Exit codes:
     "prettier/vue"
   ],
   "plugins": [
+    "babel",
     "flowtype",
     "react",
     "prettier",
@@ -498,6 +502,8 @@ Example configuration:
 
 ### [quotes]
 
+(The following applies to [babel/quotes] as well.)
+
 **This rule requires certain options and certain Prettier options.**
 
 Usually, you don’t need this rule at all. But there are two cases where it could
@@ -711,6 +717,7 @@ eslint-config-prettier has been tested with:
 - eslint-plugin-typescript 1.0.0-rc.1
 - eslint-plugin-unicorn 7.0.0
 - eslint-plugin-vue 5.1.0
+- eslint-plugin-babel 5.3.0
 
 Have new rules been added since those versions? Have we missed any rules? Is
 there a plugin you would like to see exclusions for? Open an issue or a pull
@@ -778,6 +785,7 @@ several other npm scripts:
 
 [ESlint 5.7.0]: https://eslint.org/blog/2018/10/eslint-v5.7.0-released
 [Prettier]: https://github.com/prettier/prettier
+[babel/quotes]: https://github.com/babel/eslint-plugin-babel#rules
 [curly]: https://eslint.org/docs/rules/curly
 [eslint-plugin-flowtype]: https://github.com/gajus/eslint-plugin-flowtype
 [eslint-plugin-prettier]: https://github.com/prettier/eslint-plugin-prettier
@@ -786,6 +794,7 @@ several other npm scripts:
 [eslint-plugin-typescript]: https://github.com/bradzacher/eslint-plugin-typescript
 [eslint-plugin-unicorn]: https://github.com/sindresorhus/eslint-plugin-unicorn
 [eslint-plugin-vue]: https://github.com/vuejs/eslint-plugin-vue
+[eslint-plugin-babel]: https://github.com/babel/eslint-plugin-babel
 [lines-around-comment]: https://eslint.org/docs/rules/lines-around-comment
 [max-len]: https://eslint.org/docs/rules/max-len
 [multiple configuration files]: https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy

--- a/babel.js
+++ b/babel.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+  rules: {
+    "babel/quotes": 0,
+
+    "babel/object-curly-spacing": "off",
+    "babel/semi": "off"
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,6 +1939,15 @@
       "integrity": "sha512-z541Fs5TFaY7/35v/z100InQ2f3V2J7e3u/0yKrnImgsHjh6JWgSRngfC/mZepn/+XN16jUydt64k//kxXc1fw==",
       "dev": true
     },
+    "eslint-plugin-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
     "eslint-plugin-flowtype": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.1.tgz",
@@ -2033,6 +2042,12 @@
       "requires": {
         "vue-eslint-parser": "^4.0.2"
       }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "prettier/eslint-config-prettier",
   "files": [
     "bin/",
+    "babel.js",
     "flowtype.js",
     "index.js",
     "react.js",
@@ -42,6 +43,7 @@
     "doctoc": "1.4.0",
     "eslint": "5.12.0",
     "eslint-config-google": "0.11.0",
+    "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.12.3",

--- a/test-lint/babel.js
+++ b/test-lint/babel.js
@@ -1,0 +1,6 @@
+/* eslint-disable quotes */
+"use strict";
+
+// Prettier wants spacing between curly braces, but "babel" rule added in
+// .eslintrc.base.js doesn't.
+module.exports = { foo: "bar" };


### PR DESCRIPTION
I'm not aware of any popular ESLint configs that use it so I just left it out of the configuration example for the sake of simplicity, but I think it's visible enough that people will notice that it exists.

Fixes #67.