### PR TITLE
chores on @typescript-eslint

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/member-delimiter-style": "off",
-    "@typescript-eslint/type-annotation-spacing": "off"
+    "@typescript-eslint/type-annotation-spacing": "off",
+    "@typescript-eslint/no-extra-parens": "off"
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,32 +260,34 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz",
-      "integrity": "sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.7.0.tgz",
+      "integrity": "sha512-NUSz1aTlIzzTjFFVFyzrbo8oFjHg3K/M9MzYByqbMCxeFdErhLAcGITVfXzSz+Yvp5OOpMu3HkIttB0NyKl54Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "1.4.2",
-        "@typescript-eslint/typescript-estree": "1.4.2",
+        "@typescript-eslint/parser": "1.7.0",
+        "@typescript-eslint/typescript-estree": "1.7.0",
+        "eslint-utils": "^1.3.1",
+        "regexpp": "^2.0.1",
         "requireindex": "^1.2.0",
         "tsutils": "^3.7.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.4.2.tgz",
-      "integrity": "sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.7.0.tgz",
+      "integrity": "sha512-1QFKxs2V940372srm12ovSE683afqc1jB6zF/f8iKhgLz1yoSjYeGHipasao33VXKI+0a/ob9okeogGdKGvvlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.4.2",
+        "@typescript-eslint/typescript-estree": "1.7.0",
         "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz",
-      "integrity": "sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.7.0.tgz",
+      "integrity": "sha512-K5uedUxVmlYrVkFbyV3htDipvLqTE3QMOUQEHYJaKtgzxj6r7c5Ca/DG1tGgFxX+fsbi9nDIrf4arq7Ib7H/Yw==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -6220,9 +6222,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
-      "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
+      "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "get-stdin": "^6.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "1.4.2",
-    "@typescript-eslint/parser": "1.4.2",
+    "@typescript-eslint/eslint-plugin": "1.7.0",
+    "@typescript-eslint/parser": "1.7.0",
     "babel-eslint": "10.0.1",
     "cross-spawn": "6.0.5",
     "doctoc": "1.4.0",


### PR DESCRIPTION
- updated `@typescript-eslint`
- disabled new rule `@typescript-eslint/no-extra-parens` (conflict originally found by @jgorfine)