### PR TITLE
Turn off `react/jsx-curly-newline`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,16 +1802,18 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
-      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
+      "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "resolve": "^1.10.1"
       }
@@ -4625,6 +4627,18 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "object.fromentries": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
@@ -4654,6 +4668,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-flowtype": "3.10.3",
     "eslint-plugin-prettier": "3.1.0",
-    "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react": "7.14.2",
     "eslint-plugin-standard": "4.0.0",
     "eslint-plugin-unicorn": "9.1.0",
     "eslint-plugin-vue": "5.2.2",

--- a/react.js
+++ b/react.js
@@ -5,6 +5,7 @@ module.exports = {
     "react/jsx-child-element-spacing": "off",
     "react/jsx-closing-bracket-location": "off",
     "react/jsx-closing-tag-location": "off",
+    "react/jsx-curly-newline": "off",
     "react/jsx-curly-spacing": "off",
     "react/jsx-equals-spacing": "off",
     "react/jsx-first-prop-new-line": "off",


### PR DESCRIPTION
The `react/jsx-curly-newline` rule was introduced by `eslint-plugin-react@7.14.0`.

See also:
- https://github.com/yannickcr/eslint-plugin-react/blob/v7.14.2/CHANGELOG.md#7140---2019-06-23
- https://github.com/yannickcr/eslint-plugin-react/blob/v7.14.2/docs/rules/jsx-curly-newline.md

Fix #96