### PR TITLE
Improve compatibility with standard 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
     "key-spacing": "off",
     "keyword-spacing": "off",
     "linebreak-style": "off",
+    "lines-between-class-members": "off",
     "multiline-ternary": "off",
     "newline-per-chained-call": "off",
     "new-parens": "off",

--- a/react.js
+++ b/react.js
@@ -16,6 +16,7 @@ module.exports = {
     "react/jsx-props-no-multi-spaces": "off",
     "react/jsx-space-before-closing": "off",
     "react/jsx-tag-spacing": "off",
-    "react/jsx-wrap-multilines": "off"
+    "react/jsx-wrap-multilines": "off",
+    "react/self-closing-comp": "off"
   }
 };


### PR DESCRIPTION
The `lines-between-class-members` has been added to standard 14, but is a whitespace related rule. Best to turn it off if it's not something prettier formats to.

The `react/self-closing-comp` was there in older versions of standard (I think?), but now that Prettier no longer automatically closes components, I think this should also be turned off.