### PR TITLE
Disable @typescript-eslint/no-extra-semi

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -11,6 +11,7 @@ module.exports = {
     "@typescript-eslint/no-extra-parens": "off",
     "@typescript-eslint/semi": "off",
     "@typescript-eslint/space-before-function-paren": "off",
-    "@typescript-eslint/type-annotation-spacing": "off"
+    "@typescript-eslint/type-annotation-spacing": "off",
+    "@typescript-eslint/no-extra-semi": "off"
   }
 };

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -9,9 +9,9 @@ module.exports = {
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/member-delimiter-style": "off",
     "@typescript-eslint/no-extra-parens": "off",
+    "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/semi": "off",
     "@typescript-eslint/space-before-function-paren": "off",
-    "@typescript-eslint/type-annotation-spacing": "off",
-    "@typescript-eslint/no-extra-semi": "off"
+    "@typescript-eslint/type-annotation-spacing": "off"
   }
 };

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ eslint-config-prettier has been tested with:
   - eslint-config-prettier 2.10.0 and older were tested with ESLint 4.x
   - eslint-config-prettier 2.1.1 and older were tested with ESLint 3.x
 - prettier 1.19.1
-- @typescript-eslint/eslint-plugin 2.8.0
+- @typescript-eslint/eslint-plugin 2.13.0
 - eslint-plugin-babel 5.3.0
 - eslint-plugin-flowtype 4.4.1
 - eslint-plugin-react 7.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,9 +693,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -726,12 +726,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.8.0.tgz",
-      "integrity": "sha512-ohqul5s6XEB0AzPWZCuJF5Fd6qC0b4+l5BGEnrlpmvXxvyymb8yw8Bs4YMF8usNAeuCJK87eFIHy8g8GFvOtGA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
+      "integrity": "sha512-QoiANo0MMGNa8ej/yX3BrW5dZj5d8HYcKiM2fyYUlezECqn8Xc7T/e4EUdiGinn8jhBrn+9X47E9TWaaup3u1g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.13.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -747,25 +747,25 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz",
-      "integrity": "sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.13.0.tgz",
+      "integrity": "sha512-+Hss3clwa6aNiC8ZjA45wEm4FutDV5HsVXPl/rDug1THq6gEtOYRGLqS3JlTk7mSnL5TbJz0LpEbzbPnKvY6sw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/typescript-estree": "2.13.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.8.0.tgz",
-      "integrity": "sha512-NseXWzhkucq+JM2HgqAAoKEzGQMb5LuTRjFPLQzGIdLthXMNUfuiskbl7QSykvWW6mvzCtYbw1fYWGa2EIaekw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.13.0.tgz",
+      "integrity": "sha512-vbDeLr5QRJ1K7x5iRK8J9wuGwR9OVyd1zDAY9XFAQvAosHVjSVbDgkm328ayE6hx2QWVGhwvGaEhedcqAbfQcA==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.8.0",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.13.0",
+        "@typescript-eslint/typescript-estree": "2.13.0",
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
@@ -778,9 +778,9 @@
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz",
-      "integrity": "sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.13.0.tgz",
+      "integrity": "sha512-t21Mg5cc8T3ADEUGwDisHLIubgXKjuNRbkpzDMLb7/JMmgCe/gHM9FaaujokLey+gwTuLF5ndSQ7/EfQqrQx4g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "get-stdin": "^6.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "2.8.0",
-    "@typescript-eslint/parser": "2.8.0",
+    "@typescript-eslint/eslint-plugin": "^2.13.0",
+    "@typescript-eslint/parser": "^2.13.0",
     "babel-eslint": "10.0.3",
     "cross-spawn": "6.0.5",
     "doctoc": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "get-stdin": "^6.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.13.0",
-    "@typescript-eslint/parser": "^2.13.0",
+    "@typescript-eslint/eslint-plugin": "2.13.0",
+    "@typescript-eslint/parser": "2.13.0",
     "babel-eslint": "10.0.3",
     "cross-spawn": "6.0.5",
     "doctoc": "1.4.0",


### PR DESCRIPTION
The new rule `@typescript-eslint/no-extra-semi` has been added since `@typescript-eslint/eslint-plugin@2.13.0`.

- https://github.com/typescript-eslint/typescript-eslint/blob/v2.13.0/packages/eslint-plugin/docs/rules/no-extra-semi.md
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.13.0
- typescript-eslint/typescript-eslint#1237

This rule is an extension of the ESLint core rule `no-extra-semi`,
and `eslint-config-prettier` has disabled the rule already.

- https://github.com/prettier/eslint-config-prettier/blob/dcca556e260af985ece4d9af92531fa649268f80/index.js#L52