### PR TITLE
Disable vue/max-len

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ it together with some other config.
       - [Example _double_ quote configuration](#example-_double_-quote-configuration)
       - [Example _single_ quote configuration](#example-_single_-quote-configuration)
   - [vue/html-self-closing](#vuehtml-self-closing)
-  - [vue/max-len](#max-len)
 - [Other rules worth mentioning](#other-rules-worth-mentioning)
   - [no-sequences](#no-sequences)
 - [Contributing](#contributing)
@@ -353,6 +352,8 @@ Example ESLint configuration:
 ```
 
 ### [max-len]
+
+(The following applies to [vue/max-len] as well.)
 
 **This rule requires special attention when writing code.**
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ it together with some other config.
       - [Example _double_ quote configuration](#example-_double_-quote-configuration)
       - [Example _single_ quote configuration](#example-_single_-quote-configuration)
   - [vue/html-self-closing](#vuehtml-self-closing)
+  - [vue/max-len](#max-len)
 - [Other rules worth mentioning](#other-rules-worth-mentioning)
   - [no-sequences](#no-sequences)
 - [Contributing](#contributing)
@@ -804,7 +805,7 @@ eslint-config-prettier has been tested with:
 - eslint-plugin-react 7.17.0
 - eslint-plugin-standard 4.0.1
 - eslint-plugin-unicorn 15.0.1
-- eslint-plugin-vue 6.0.1
+- eslint-plugin-vue 6.1.1
 
 Have new rules been added since those versions? Have we missed any rules? Is
 there a plugin you would like to see exclusions for? Open an issue or a pull
@@ -906,3 +907,4 @@ several other npm scripts:
 [travis-badge]: https://travis-ci.org/prettier/eslint-config-prettier.svg?branch=master
 [travis]: https://travis-ci.org/prettier/eslint-config-prettier
 [vue/html-self-closing]: https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-self-closing.md
+[vue/max-len]: https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,12 +2512,12 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.0.1.tgz",
-      "integrity": "sha512-5tgFPcxGDKjfVB/6Yi56bKiWxygUibfZmzSh26Np3kuwAk/lfaGbVld+Yt+MPgD84ppvcachtiL4/winsXLjXA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.1.1.tgz",
+      "integrity": "sha512-WsJcndi3iOtKF+Wkrw7mWiKT3GdGYUM8onbWYX7sBgggiFKoxHyx8VciA5letkx6iKzoW4B7XrBeVdTukmrtpg==",
       "dev": true,
       "requires": {
-        "vue-eslint-parser": "^6.0.5"
+        "vue-eslint-parser": "^7.0.0"
       }
     },
     "eslint-rule-composer": {
@@ -7540,45 +7540,24 @@
       }
     },
     "vue-eslint-parser": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-6.0.5.tgz",
-      "integrity": "sha512-Bvjlx7rH1Ulvus56KHeLXOjEi3JMOYTa1GAqZr9lBQhd8weK8mV7U7V2l85yokBZEWHJQjLn6X3nosY8TzkOKg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
+      "integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
           "dev": true
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-          "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^6.0.7",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
     "eslint-plugin-unicorn": "15.0.1",
-    "eslint-plugin-vue": "6.0.1",
+    "eslint-plugin-vue": "6.1.1",
     "jest": "24.9.0",
     "prettier": "1.19.1",
     "replace": "1.1.1",

--- a/vue.js
+++ b/vue.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     "vue/html-self-closing": 0,
+    "vue/max-len": 0,
 
     "vue/array-bracket-spacing": "off",
     "vue/arrow-spacing": "off",


### PR DESCRIPTION
The new rule `vue/max-len` has been added since `eslint-plugin-vue@6.1.0`.

- https://eslint.vuejs.org/rules/max-len.html
- https://github.com/vuejs/eslint-plugin-vue/releases/tag/v6.1.0
- https://github.com/vuejs/eslint-plugin-vue/pull/959

This rule is an extension of the ESLint core rule `max-len`,
and `eslint-config-prettier` has disabled the rule already by setting value to `0`.

- https://github.com/prettier/eslint-config-prettier/blob/d6bf4c063dfaf1de0b5c22ba0156184955b39b44/index.js#L14