### PR TITLE
Prettier 2.0 rules update

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = {
       "array-bracket-newline": "off",
       "array-bracket-spacing": "off",
       "array-element-newline": "off",
-      "arrow-parens": "off",
       "arrow-spacing": "off",
       "block-spacing": "off",
       "brace-style": "off",


### PR DESCRIPTION
**Arrow Function Parentheses**
_First available in v1.9.0, default value changed from avoid to always in v2.0.0_

Corrected by removing the `arrow-parens` rule.

**Trailing Commas**
_Default value changed from none to es5 in v2.0.0_

I've tried correcting the trailing commas notice by removing `comma-dangle` and `no-comma-dangle` but it still reports it.
