### PR TITLE
Clarify what to add to .eslintrc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Install eslint-config-prettier:
 npm install --save-dev eslint-config-prettier
 ```
 
-Then, add eslint-config-prettier to the "extends" array in your `.eslintrc.*` file. Make sure to put it **last,** so it gets the chance to override other configs.
+Then, add `"prettier"` to the "extends" array in your `.eslintrc.*` file. Make sure to put it **last,** so it gets the chance to override other configs.
 
 <!-- prettier-ignore -->
 ```json


### PR DESCRIPTION
`README.md` says to add eslint-config-prettier to your `.eslintrc.*` file, but it's supposed to be `"prettier"` as far as I can tell. The code example also shows `"prettier"` instead of `"eslint-config-prettier"` on the very next line. A little confusing, but easily fixable 😄