### PR TITLE
Remove "vue/html-end-tags": "off"

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,6 @@ module.exports = {
     "vue/func-call-spacing": "off",
     "vue/html-closing-bracket-newline": "off",
     "vue/html-closing-bracket-spacing": "off",
-    "vue/html-end-tags": "off",
     "vue/html-indent": "off",
     "vue/html-quotes": "off",
     "vue/key-spacing": "off",


### PR DESCRIPTION
If not open "vue/html-end-tags", the following error will not be checked out, which lead to an our online accident.

```vue
<div>
  <div>
    <span>haha</span>
  <!-- </div> -->
  <div>
    hehe
  </div>
</div>
```