### PR TITLE
ci: harden workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
       - "main"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - "main"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ${{ matrix.os }}
@@ -17,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR:

-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
- Declares the minimum permissions for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)