### PR TITLE
Move removed rules to deprecated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Extending `"prettier"` turns off a bunch of core ESLint rules, as well as a few 
 
 ### Excluding deprecated rules
 
-Some of the rules that eslint-config-prettier turns off may be deprecated. **This is perfectly fine,** but if you really need to omit the deprecated rules, you can do so by setting the `ESLINT_CONFIG_PRETTIER_NO_DEPRECATED` environment variable to a non-empty value. For example:
+Some of the rules that eslint-config-prettier turns off may be deprecated, or even removed from ESLint. **This is perfectly fine,** but if you really need to omit the deprecated and removed rules, you can do so by setting the `ESLINT_CONFIG_PRETTIER_NO_DEPRECATED` environment variable to a non-empty value. For example:
 
 ```
 env ESLINT_CONFIG_PRETTIER_NO_DEPRECATED=true npx eslint-find-rules --deprecated index.js

--- a/index.js
+++ b/index.js
@@ -194,9 +194,6 @@ module.exports = {
       // Deprecated since version 3.3.0.
       // https://eslint.org/docs/rules/no-spaced-func
       "no-spaced-func": "off",
-      // Deprecated since version 7.0.0.
-      // https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06
-      "react/jsx-space-before-closing": "off",
       // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/space-after-function-name
       "space-after-function-name": "off",
@@ -218,6 +215,9 @@ module.exports = {
       // Removed in version 0.10.0.
       // https://eslint.org/docs/latest/rules/space-unary-word-ops
       "space-unary-word-ops": "off",
+      // Deprecated since version 7.0.0.
+      // https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06
+      "react/jsx-space-before-closing": "off",
     }),
   },
 };

--- a/index.js
+++ b/index.js
@@ -170,22 +170,22 @@ module.exports = {
     "vue/template-curly-spacing": "off",
 
     ...(includeDeprecated && {
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/generator-star
       "generator-star": "off",
-      // Deprecated since version 2.0.0.
+      // Removed in version 2.0.0.
       // https://eslint.org/docs/latest/rules/no-arrow-condition
       "no-arrow-condition": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/no-comma-dangle
       "no-comma-dangle": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/no-reserved-keys
       "no-reserved-keys": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/no-space-before-semi
       "no-space-before-semi": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/no-wrap-func
       "no-wrap-func": "off",
       // Deprecated since version 4.0.0.
@@ -197,25 +197,25 @@ module.exports = {
       // Deprecated since version 7.0.0.
       // https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06
       "react/jsx-space-before-closing": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/space-after-function-name
       "space-after-function-name": "off",
-      // Deprecated since version 2.0.0.
+      // Removed in version 2.0.0.
       // https://eslint.org/docs/latest/rules/space-after-keywords
       "space-after-keywords": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/space-before-function-parentheses
       "space-before-function-parentheses": "off",
-      // Deprecated since version 2.0.0.
+      // Removed in version 2.0.0.
       // https://eslint.org/docs/latest/rules/space-before-keywords
       "space-before-keywords": "off",
-      // Deprecated since version 1.0.0.
+      // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/space-in-brackets
       "space-in-brackets": "off",
-      // Deprecated since version 2.0.0.
+      // Removed in version 2.0.0.
       // https://eslint.org/docs/latest/rules/space-return-throw-case
       "space-return-throw-case": "off",
-      // Deprecated since version 0.10.0.
+      // Removed in version 0.10.0.
       // https://eslint.org/docs/latest/rules/space-unary-word-ops
       "space-unary-word-ops": "off",
     }),

--- a/index.js
+++ b/index.js
@@ -173,6 +173,9 @@ module.exports = {
       // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/generator-star
       "generator-star": "off",
+      // Deprecated since version 4.0.0.
+      // https://github.com/eslint/eslint/pull/8286
+      "indent-legacy": "off",
       // Removed in version 2.0.0.
       // https://eslint.org/docs/latest/rules/no-arrow-condition
       "no-arrow-condition": "off",
@@ -185,15 +188,12 @@ module.exports = {
       // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/no-space-before-semi
       "no-space-before-semi": "off",
-      // Removed in version 1.0.0.
-      // https://eslint.org/docs/latest/rules/no-wrap-func
-      "no-wrap-func": "off",
-      // Deprecated since version 4.0.0.
-      // https://github.com/eslint/eslint/pull/8286
-      "indent-legacy": "off",
       // Deprecated since version 3.3.0.
       // https://eslint.org/docs/rules/no-spaced-func
       "no-spaced-func": "off",
+      // Removed in version 1.0.0.
+      // https://eslint.org/docs/latest/rules/no-wrap-func
+      "no-wrap-func": "off",
       // Removed in version 1.0.0.
       // https://eslint.org/docs/latest/rules/space-after-function-name
       "space-after-function-name": "off",

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ module.exports = {
     "func-call-spacing": "off",
     "function-call-argument-newline": "off",
     "function-paren-newline": "off",
-    "generator-star": "off",
     "generator-star-spacing": "off",
     "implicit-arrow-linebreak": "off",
     "indent": "off",
@@ -48,19 +47,14 @@ module.exports = {
     "multiline-ternary": "off",
     "newline-per-chained-call": "off",
     "new-parens": "off",
-    "no-arrow-condition": "off",
-    "no-comma-dangle": "off",
     "no-extra-parens": "off",
     "no-extra-semi": "off",
     "no-floating-decimal": "off",
     "no-mixed-spaces-and-tabs": "off",
     "no-multi-spaces": "off",
     "no-multiple-empty-lines": "off",
-    "no-reserved-keys": "off",
-    "no-space-before-semi": "off",
     "no-trailing-spaces": "off",
     "no-whitespace-before-property": "off",
-    "no-wrap-func": "off",
     "nonblock-statement-body-position": "off",
     "object-curly-newline": "off",
     "object-curly-spacing": "off",
@@ -73,18 +67,11 @@ module.exports = {
     "semi": "off",
     "semi-spacing": "off",
     "semi-style": "off",
-    "space-after-function-name": "off",
-    "space-after-keywords": "off",
     "space-before-blocks": "off",
     "space-before-function-paren": "off",
-    "space-before-function-parentheses": "off",
-    "space-before-keywords": "off",
-    "space-in-brackets": "off",
     "space-in-parens": "off",
     "space-infix-ops": "off",
-    "space-return-throw-case": "off",
     "space-unary-ops": "off",
-    "space-unary-word-ops": "off",
     "switch-colon-spacing": "off",
     "template-curly-spacing": "off",
     "template-tag-spacing": "off",
@@ -183,6 +170,24 @@ module.exports = {
     "vue/template-curly-spacing": "off",
 
     ...(includeDeprecated && {
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/generator-star
+      "generator-star": "off",
+      // Deprecated since version 2.0.0.
+      // https://eslint.org/docs/latest/rules/no-arrow-condition
+      "no-arrow-condition": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/no-comma-dangle
+      "no-comma-dangle": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/no-reserved-keys
+      "no-reserved-keys": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/no-space-before-semi
+      "no-space-before-semi": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/no-wrap-func
+      "no-wrap-func": "off",
       // Deprecated since version 4.0.0.
       // https://github.com/eslint/eslint/pull/8286
       "indent-legacy": "off",
@@ -192,6 +197,27 @@ module.exports = {
       // Deprecated since version 7.0.0.
       // https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06
       "react/jsx-space-before-closing": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/space-after-function-name
+      "space-after-function-name": "off",
+      // Deprecated since version 2.0.0.
+      // https://eslint.org/docs/latest/rules/space-after-keywords
+      "space-after-keywords": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/space-before-function-parentheses
+      "space-before-function-parentheses": "off",
+      // Deprecated since version 2.0.0.
+      // https://eslint.org/docs/latest/rules/space-before-keywords
+      "space-before-keywords": "off",
+      // Deprecated since version 1.0.0.
+      // https://eslint.org/docs/latest/rules/space-in-brackets
+      "space-in-brackets": "off",
+      // Deprecated since version 2.0.0.
+      // https://eslint.org/docs/latest/rules/space-return-throw-case
+      "space-return-throw-case": "off",
+      // Deprecated since version 0.10.0.
+      // https://eslint.org/docs/latest/rules/space-unary-word-ops
+      "space-unary-word-ops": "off",
     }),
   },
 };


### PR DESCRIPTION
Move many rules to deprecated section:

- [`generator-star`](https://eslint.org/docs/latest/rules/generator-star): _This rule was removed in ESLint v1.0 and replaced by the [generator-star-spacing](https://eslint.org/docs/latest/rules/generator-star-spacing) rule._
- [`no-arrow-condition`](https://eslint.org/docs/latest/rules/no-arrow-condition): _This rule was removed in ESLint v2.0 and replaced by a combination of the [no-confusing-arrow](https://eslint.org/docs/latest/rules/no-confusing-arrow) and [no-constant-condition](https://eslint.org/docs/latest/rules/no-constant-condition) rules._
- [`no-comma-dangle`](https://eslint.org/docs/latest/rules/no-comma-dangle): _This rule was removed in ESLint v1.0 and replaced by the [comma-dangle](https://eslint.org/docs/latest/rules/comma-dangle) rule._
- [`no-reserved-keys`](https://eslint.org/docs/latest/rules/no-reserved-keys): _This rule was removed in ESLint v1.0 and replaced by the [quote-props](https://eslint.org/docs/latest/rules/quote-props) rule._
- [`no-space-before-semi`](https://eslint.org/docs/latest/rules/no-space-before-semi): _This rule was removed in ESLint v1.0 and replaced by the [semi-spacing](https://eslint.org/docs/latest/rules/semi-spacing) rule._
- [`no-wrap-func`](https://eslint.org/docs/latest/rules/no-wrap-func): _This rule was removed in ESLint v1.0 and replaced by the [no-extra-parens](https://eslint.org/docs/latest/rules/no-extra-parens) rule. The "functions" option in the new rule is equivalent to the removed rule._
- [`space-after-function-name`](https://eslint.org/docs/latest/rules/): _This rule was removed in ESLint v1.0 and replaced by the [space-before-function-paren](https://eslint.org/docs/latest/rules/space-before-function-paren) rule._
- [`space-after-keywords`](https://eslint.org/docs/latest/rules/space-after-keywords): _This rule was removed in ESLint v2.0 and replaced by the [keyword-spacing](https://eslint.org/docs/latest/rules/keyword-spacing) rule._
- [`space-before-function-parentheses`](https://eslint.org/docs/latest/rules/space-before-function-parentheses): _This rule was removed in ESLint v1.0 and replaced by the [space-before-function-paren](https://eslint.org/docs/latest/rules/space-before-function-paren) rule. The name of the rule changed from “parentheses” to “paren” for consistency with the names of other rules._
- [`space-before-keywords`](https://eslint.org/docs/latest/rules/space-before-keywords): _This rule was removed in ESLint v2.0 and replaced by the [keyword-spacing](https://eslint.org/docs/latest/rules/keyword-spacing) rule._
- [`space-in-brackets`](https://eslint.org/docs/latest/rules/space-in-brackets): _This rule was removed in ESLint v1.0 and replaced by the [object-curly-spacing](https://eslint.org/docs/latest/rules/object-curly-spacing) and [array-bracket-spacing](https://eslint.org/docs/latest/rules/array-bracket-spacing) rules._
- [`space-return-throw-case`](https://eslint.org/docs/latest/rules/space-return-throw-case): _This rule was removed in ESLint v2.0 and replaced by the [keyword-spacing](https://eslint.org/docs/latest/rules/keyword-spacing) rule._
- [`space-unary-word-ops`](https://eslint.org/docs/latest/rules/space-unary-word-ops): _This rule was removed in ESLint v0.10.0 and replaced by the [space-unary-ops](https://eslint.org/docs/latest/rules/space-unary-ops) rule._