### PR TITLE
Do not disable unicode-bom

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ module.exports = {
     "switch-colon-spacing": "off",
     "template-curly-spacing": "off",
     "template-tag-spacing": "off",
-    "unicode-bom": "off",
     "wrap-iife": "off",
     "wrap-regex": "off",
     "yield-star-spacing": "off",


### PR DESCRIPTION
Prettier does not add/remove BOM from files afaict, so this rule should not be disabled.

Related:
https://github.com/prettier/prettier/issues/6461