### PR TITLE
Fix ECMA version in internal ESLint config

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -25,7 +25,6 @@ module.exports = {
     ),
   ],
   parserOptions: {
-    parser: "@babel/eslint-parser",
     ecmaVersion: 2018,
     sourceType: "script",
     // Needed for the lint-verify-fail.test.js test.
@@ -83,6 +82,10 @@ module.exports = {
         // This is included in "plugin:@typescript-eslint/recommended".
         "@typescript-eslint/indent": "error",
       },
+    },
+    {
+      files: ["test-lint/{react,flowtype}.js"],
+      parserOptions: { parser: "@babel/eslint-parser" },
     },
   ],
   settings: {

--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -27,11 +27,6 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "script",
-    // Needed for the lint-verify-fail.test.js test.
-    loggerFn: () => {},
-    ecmaFeatures: {
-      jsx: true,
-    },
   },
   env: {
     es6: true,

--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -60,6 +60,7 @@ module.exports = {
     "unicorn/prefer-flat-map": "off",
     "unicorn/prefer-module": "off",
     "unicorn/prefer-node-protocol": "off",
+    "unicorn/prefer-optional-catch-binding": "off",
     "unicorn/prefer-spread": "off",
     "unicorn/prefer-top-level-await": "off",
     "unicorn/prevent-abbreviations": "off",

--- a/eslint.base.config.js
+++ b/eslint.base.config.js
@@ -9,7 +9,6 @@ const fs = require("fs");
 const path = require("path");
 const babelOld = require("eslint-plugin-babel");
 const babelNew = require("@babel/eslint-plugin");
-const babelParser = require("@babel/eslint-parser");
 const flowtype = require("eslint-plugin-flowtype");
 const globals = require("globals");
 const google = require("eslint-config-google");
@@ -65,7 +64,6 @@ module.exports = [
         ...globals.es6,
         ...globals.node,
       },
-      parser: babelParser,
     },
     rules: eslintrcBase.rules,
     settings: eslintrcBase.settings,

--- a/test-lint/unicorn.js
+++ b/test-lint/unicorn.js
@@ -8,4 +8,4 @@
 // Prettier wants line break in `try`, but
 // `plugin:unicorn/recommended` wants whitespace removed.
 try {
-} catch {}
+} catch (_error) {}


### PR DESCRIPTION
Our internal ESLint config says `ecmaVersion: 2018`, but still allows syntax from ES2019+ since we also use `@babel/parser`.

This PR changes to using the default parser, except for react and flow where we use babel (for JSX and type annotations).

At some point we could bump `ecmaVersion` to be able to use newer language features, but right now that’s an unnecessary potentially breaking change. We only test supported Node.js in GitHub Actions, but I just tested manually and eslint-config-prettier still works in Node.js 12 which use just two LTS behind. Given eslint-config-prettier’s popularity I see no reason to break that for now.