### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/.changeset/six-dolls-itch.md
+++ b/.changeset/six-dolls-itch.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-prettier": patch
+---
+
+chore(package): explicitly declare js module type

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "prettier/eslint-config-prettier",
   "bin": "build/bin/cli.js",
   "main": "build/index.js",
+  "type": "commonjs",
   "files": [
     "build"
   ],


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0) that became enabled by [default in Node 22.7.0](https://nodejs.org/api/packages.html#syntax-detection).
Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.