### PR TITLE
fix: use non-enumerable property to bypass eslintrc validation

### DIFF
--- a/.changeset/friendly-hounds-dress.md
+++ b/.changeset/friendly-hounds-dress.md
@@ -4,4 +4,4 @@
 
 fix: use non-enumerable property to bypass eslintrc validation
 
-Note for `v10.1.1` user, `/flat` entry is removed (sorry) because `eslintrc` compatibility issue has been resolved
+Note for `v10.1.1` users, `/flat` entry is removed (sorry) because `eslintrc` compatibility issue has been resolved

--- a/.changeset/friendly-hounds-dress.md
+++ b/.changeset/friendly-hounds-dress.md
@@ -1,0 +1,7 @@
+---
+"eslint-config-prettier": patch
+---
+
+fix: use non-enumerable property to bypass eslintrc validation
+
+Note for `v10.1.1` user, `/flat` entry is removed (sorry) because `eslintrc` compatibility issue has been resolved

--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ Note that this config _only_ turns rules _off,_ so it only makes sense using it 
      <!-- prettier-ignore -->
      ```js
      import someConfig from "some-other-config-you-use";
-     // Note the `/flat` suffix here, the difference from default entry is that
-     // `/flat` added `name` property to the exported object to improve
-     // [config-inspector](https://eslint.org/blog/2024/04/eslint-config-inspector/) experience.
-     import eslintConfigPrettier from "eslint-config-prettier/flat";
+     import eslintConfigPrettier from "eslint-config-prettier";
 
      export default [
        someConfig,
@@ -84,7 +81,7 @@ With flat config, _you_ get to decide the plugin name! For example:
 
 ```js
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import eslintConfigPrettier from "eslint-config-prettier/flat";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
   {
@@ -156,7 +153,7 @@ For eslintrc, while the `"prettier"` config can disable problematic rules in `"s
 
 ```js
 import someConfig from "some-other-config-you-use";
-import eslintConfigPrettier from "eslint-config-prettier/flat";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
   someConfig,
@@ -173,7 +170,7 @@ With the new ESLint “flat config” format, you can control what things overri
 
 ```js
 import someConfig from "some-other-config-you-use";
-import eslintConfigPrettier from "eslint-config-prettier/flat";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
   someConfig,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,13 +10,13 @@
 
 const globals = require("globals");
 const base = require("./eslint.base.config");
-const flat = require("./flat.js");
+const index = require("./index.js");
 const prettier = require("./prettier");
 const eslintrc = require("./.eslintrc");
 
 module.exports = [
   ...base,
-  flat,
+  index,
   prettier,
   {
     rules: eslintrc.rules,

--- a/flat.d.ts
+++ b/flat.d.ts
@@ -1,3 +1,0 @@
-export * from "./index.js";
-
-export const name: "config-prettier";

--- a/flat.js
+++ b/flat.js
@@ -1,6 +1,0 @@
-"use strict";
-
-const { rules } = require("./index.js");
-
-exports.name = "config-prettier";
-exports.rules = rules;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
+export const name: 'config-prettier';
+
 export const rules: Record<string, 0 | "off">;

--- a/index.js
+++ b/index.js
@@ -393,3 +393,10 @@ exports.rules = {
     "react/jsx-space-before-closing": "off",
   }),
 };
+
+Object.defineProperty(exports, "name", {
+  value: "config-prettier",
+  configurable: false,
+  writable: false,
+  enumerable: false,
+});

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   "types": "index.d.ts",
   "files": [
     "bin",
-    "flat.d.ts",
-    "flat.js",
     "index.d.ts",
     "index.js",
     "prettier.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
-    "./flat": {
-      "types": "./flat.d.ts",
-      "default": "./flat.js"
-    },
     "./prettier": {
       "types": "./prettier.d.ts",
       "default": "./prettier.js"


### PR DESCRIPTION
related #308

Thanks @fisker for this pattern at https://github.com/prettier/eslint-config-prettier/pull/309#issuecomment-2706091557