### PR TITLE
chore(package): add homepage url

### DIFF
--- a/.changeset/purple-ravens-pump.md
+++ b/.changeset/purple-ravens-pump.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-prettier": patch
+---
+
+chore(package): add homepage for some 3rd-party registry - close #321

--- a/.changeset/purple-ravens-pump.md
+++ b/.changeset/purple-ravens-pump.md
@@ -2,4 +2,4 @@
 "eslint-config-prettier": patch
 ---
 
-chore(package): add homepage for some 3rd-party registry - close #321
+chore(package): add homepage for some 3rd-party registry - see [#321](https://github.com/prettier/eslint-config-prettier/pull/321) for more details

--- a/package.json
+++ b/package.json
@@ -3,14 +3,8 @@
   "version": "10.1.1",
   "type": "commonjs",
   "description": "Turns off all rules that are unnecessary or might conflict with Prettier.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/prettier/eslint-config-prettier.git"
-  },
+  "repository": "prettier/eslint-config-prettier",
   "homepage": "https://github.com/prettier/eslint-config-prettier#readme",
-  "bugs": {
-    "url": "https://github.com/prettier/eslint-config-prettier/issues"
-  },
   "author": "Simon Lydell",
   "maintainers": [
     "JounQin (https://www.1stG.me) <admin@1stg.me>"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,14 @@
   "version": "10.1.1",
   "type": "commonjs",
   "description": "Turns off all rules that are unnecessary or might conflict with Prettier.",
-  "repository": "prettier/eslint-config-prettier",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prettier/eslint-config-prettier.git"
+  },
+  "homepage": "https://github.com/prettier/eslint-config-prettier#readme",
+  "bugs": {
+    "url": "https://github.com/prettier/eslint-config-prettier/issues"
+  },
   "author": "Simon Lydell",
   "maintainers": [
     "JounQin (https://www.1stG.me) <admin@1stg.me>"


### PR DESCRIPTION

The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![Untitled](https://github.com/user-attachments/assets/a008d7f8-55fd-4964-8a76-fffd1899f471)

Compared to something like eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)
