### PR TITLE
fix(cli): do not crash on no rules configured

### DIFF
--- a/.changeset/lazy-dingos-cheat.md
+++ b/.changeset/lazy-dingos-cheat.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-prettier": patch
+---
+
+fix(cli): do not crash on no rules configured

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,7 +60,7 @@ if (module === require.main) {
     })
   )
     .then((configs) => {
-      const rules = configs.flatMap(({ rules }, index) =>
+      const rules = configs.flatMap(({ rules = {} } = {}, index) =>
         Object.entries(rules).map((entry) => [...entry, args[index]])
       );
       const result = processRules(rules);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,8 +60,13 @@ if (module === require.main) {
     })
   )
     .then((configs) => {
-      const rules = configs.flatMap(({ rules = {} } = {}, index) =>
-        Object.entries(rules).map((entry) => [...entry, args[index]])
+      const rules = configs.flatMap(
+        (
+          // Initializing config and rules for files that aren't included in the flat config,
+          // which is a very unlikely scenario, but should still be treated as a success
+          { rules = {} } = {},
+          index
+        ) => Object.entries(rules).map((entry) => [...entry, args[index]])
       );
       const result = processRules(rules);
       if (result.stderr) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const childProcess = require("child_process");
+const path = require("path");
 const cli = require("../bin/cli");
 
 const offPatterns = [0, "off", [0], ["off"], ["off", "never"]];
@@ -74,6 +76,14 @@ test("no results", () => {
       "stdout": "No rules that are unnecessary or conflict with Prettier were found.",
     }
   `);
+});
+
+test("empty config", (done) => {
+  childProcess.exec(
+    `node ${path.join(process.cwd(), "bin/cli.js")} index.js`,
+    { cwd: path.join(__dirname, "fixtures/empty-config") },
+    done
+  );
 });
 
 test("conflicting options", () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,7 +1,8 @@
 "use strict";
 
-const childProcess = require("child_process");
-const path = require("path");
+const childProcess = require("node:child_process");
+const path = require("node:path");
+
 const cli = require("../bin/cli");
 
 const offPatterns = [0, "off", [0], ["off"], ["off", "never"]];
@@ -80,8 +81,8 @@ test("no results", () => {
 
 test("empty config", (done) => {
   childProcess.exec(
-    `node ${path.join(process.cwd(), "bin/cli.js")} index.js`,
-    { cwd: path.join(__dirname, "fixtures/empty-config") },
+    `node ${path.resolve("bin/cli.js")} index.js`,
+    { cwd: path.resolve(__dirname, "fixtures/empty-config") },
     done
   );
 });

--- a/test/fixtures/empty-config/eslint.config.mjs
+++ b/test/fixtures/empty-config/eslint.config.mjs
@@ -1,0 +1,1 @@
+export default [{}];


### PR DESCRIPTION
In the case when a flat config has no rules defined, the resolved config for a file is `undefined`.

```js
// eslint.config.js
export default [{}]
```

This causes the CLI utility to fail to destructure `rules` out of it:

```
❯ npx eslint-config-prettier src/utils/toast.tsx
Cannot destructure property 'rules' of 'undefined' as it is undefined.
```

and it's also necessary to initialize `rules` as well, because `Object.entries(undefined)` is an error.

This will achieve the same behavior as a legacy configuration:

```js
// .eslintrc.cjs
module.exports = {}
```

```
❯ npx eslint-config-prettier src/utils/toast.tsx
No rules that are unnecessary or conflict with Prettier were found.
```

Fixes #288.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CLI crash in `bin/cli.js` by setting default `rules = {}` for flat configs with no rules, ensuring consistent behavior with legacy configurations.
> 
>   - **Behavior**:
>     - Fixes CLI utility crash in `bin/cli.js` when flat config has no rules defined by setting default `rules = {}` during destructuring.
>     - Ensures consistent behavior with legacy configuration by outputting "No rules that are unnecessary or conflict with Prettier were found." when no rules are present.
>   - **Misc**:
>     - Fixes #288.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-config-prettier&utm_source=github&utm_medium=referral)<sup> for 0b826290b6a1a3402ad999af07d8b87a05e797a6. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by preventing potential errors when configuration objects or their properties are missing.
	- Ensured the CLI runs smoothly even with empty or missing configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->