### PR TITLE
Disable `@stylistic/curly-newline`

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ exports.rules = {
   "@stylistic/comma-spacing": "off",
   "@stylistic/comma-style": "off",
   "@stylistic/computed-property-spacing": "off",
+  "@stylistic/curly-newline": "off",
   "@stylistic/dot-location": "off",
   "@stylistic/eol-last": "off",
   "@stylistic/func-call-spacing": "off",


### PR DESCRIPTION
Introduced in October 2024: https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v2.9.0

https://eslint.style/rules/curly-newline
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables `@stylistic/curly-newline` rule in `index.js`, aligning with other stylistic rules disabled for Prettier.
> 
>   - **Behavior**:
>     - Disables `@stylistic/curly-newline` rule in `index.js` by setting it to "off".
>     - Aligns with other stylistic rules that are disabled when using Prettier.
>   - **Context**:
>     - `@stylistic/curly-newline` was introduced in October 2024.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-config-prettier&utm_source=github&utm_medium=referral)<sup> for 5c04f61d9d9594558f8c5230a6a3a9c95f8f6c92. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled enforcement of the curly newline stylistic rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->