### PR TITLE
docs: update CLI Helper tools section path name and add notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ env ESLINT_CONFIG_PRETTIER_NO_DEPRECATED=true npx eslint-find-rules --deprecated
 eslint-config-prettier also ships with a little CLI tool to help you check if your configuration contains any rules that are unnecessary or conflict with Prettier. Here’s how to run it:
 
 ```
-npx eslint-config-prettier path/to/main.js
+npx eslint-config-prettier path/to/config.js
 ```
 
-(Change `path/to/main.js` to a file that exists in your project.)
+Note: Change `path/to/config.js` to the actual path of your ESLint configuration file, such as `.eslintrc` or `eslint.config.js` in your project.
 
 ### What and why
 


### PR DESCRIPTION
Solve #346 


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CLI helper tool path and add clarification note in `README.md`.
> 
>   - **Documentation**:
>     - Update CLI helper tool example path from `path/to/main.js` to `path/to/config.js` in `README.md`.
>     - Add note to clarify that `path/to/config.js` should be replaced with the actual ESLint configuration file path, such as `.eslintrc` or `eslint.config.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-config-prettier&utm_source=github&utm_medium=referral)<sup> for 6ae5cc3c1d088b5802300ec2f0a6b3ee0503164b. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify CLI usage: example now points to the ESLint configuration file path rather than a main script path.
  * Enhanced explanatory note to reference common config filenames (e.g., .eslintrc, eslint.config.js) for clearer setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->